### PR TITLE
Fix redstone ore mining in Minecraft 1.13

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -129,3 +129,4 @@ Aliases:
 - 'minecraft:jungle_log,minecraft:jungle_wood'
 - 'minecraft:oak_log,minecraft:oak_wood'
 - 'minecraft:spruce_log,minecraft:spruce_wood'
+- 'minecraft:redstone_ore,minecraft:redstone_ore[lit=true]'


### PR DESCRIPTION
Redstone ore does not mine properly in Minecraft 1.13 because Redstone Ore has two different BlockStates. Adding an alias with `- 'minecraft:redstone_ore,minecraft:redstone_ore[lit=true]'` fixes this.