### PR TITLE
Fix possible bug in readUnsafe()

### DIFF
--- a/src/main/java/wtf/choco/veinminer/data/AlgorithmConfig.java
+++ b/src/main/java/wtf/choco/veinminer/data/AlgorithmConfig.java
@@ -251,7 +251,7 @@ public class AlgorithmConfig implements Cloneable {
             this.repairFriendly((boolean) repairFriendlyVeinMiner);
         }
         if (includeEdges instanceof Boolean) {
-            this.repairFriendly((boolean) includeEdges);
+            this.includeEdges((boolean) includeEdges);
         }
         if (maxVeinSize instanceof Integer) {
             this.maxVeinSize(Math.max((int) maxVeinSize, 1));


### PR DESCRIPTION
After reading through the source code, I noticed this. Pretty sure this is not supposed to be this way