### PR TITLE
Don't integrate mcMMO-Classic

### DIFF
--- a/VeinMiner-Bukkit/src/main/java/wtf/choco/veinminer/VeinMiner.java
+++ b/VeinMiner-Bukkit/src/main/java/wtf/choco/veinminer/VeinMiner.java
@@ -88,7 +88,7 @@ public final class VeinMiner extends JavaPlugin {
 
     @Override
     public void onLoad() {
-        if (Bukkit.getPluginManager().getPlugin("WorldGuard") != null) {
+        if (Bukkit.getPluginManager().isPluginEnabled("WorldGuard")) {
             this.getLogger().info("Found WorldGuard. Registering custom region flag.");
             WorldGuardIntegration.init(this);
         }
@@ -128,7 +128,12 @@ public final class VeinMiner extends JavaPlugin {
         manager.registerEvents(new ItemCollectionListener(this), this);
         manager.registerEvents(new PlayerDataListener(this), this);
 
-        if (manager.getPlugin("mcMMO") != null) {
+        if (manager.isPluginEnabled("mcMMO")) {
+            // Prevent integration with mcMMO-Classic (for now)
+            // TODO: Support mcMMO-Classic? https://github.com/mcMMO-Dev/mcMMO-Classic/
+            if (manager.getPlugin("mcMMO").getDescription().getVersion().startsWith("1")) {
+                return;
+            }
             manager.registerEvents(new McMMOIntegration(this), this);
         }
 


### PR DESCRIPTION
Registering this listener with mcMMO-Classic installed will cause a whole bunch of `NoSuchMethodError` errors to be spit out. Also changes to the plugin manager method which accounts for any scenarios where the plugin doesn't get enabled (e.g. where the plugin will not be null but won't be enabled because a dependency isn't installed).