### PR TITLE
Update Gradle, change API from Bukkit to Spigot

### DIFF
--- a/VeinMiner-Bukkit/build.gradle
+++ b/VeinMiner-Bukkit/build.gradle
@@ -19,8 +19,8 @@ repositories {
 dependencies {
     implementation 'org.bstats:bstats-bukkit:2.2.1'
 
-    // Building against Bukkit 1.17, but support for 1.13 is still retained through reflective access
-    compileOnly 'org.bukkit:bukkit:1.17-R0.1-SNAPSHOT'
+    // Swap to Spigot 1.17 as Bukkit API is not updated after 1.15.2
+    compileOnly 'org.spigotmc:spigot-api:1.17-R0.1-SNAPSHOT'
     compileOnly 'org.jetbrains:annotations:18.0.0'
 
     compileOnly 'net.milkbowl.vault:VaultAPI:1.7'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I noticed that Java 16 is supported with release from Gradle v7 onwards, so to support workflow, Gradle is updated to 7.1. 
I also noticed that you are referencing Bukkit 1.17, unfortunately, from 1.15.2 onwards, Bukkit is no longer updated. Thus I changed the dependency from Bukkit to Spigot 1.17 API.